### PR TITLE
Use lifecycle instead regular nodes for retrieving node from blackboard

### DIFF
--- a/plansys2_bt_example/src/behavior_tree_nodes/Move.cpp
+++ b/plansys2_bt_example/src/behavior_tree_nodes/Move.cpp
@@ -20,7 +20,7 @@
 #include "plansys2_bt_example/behavior_tree_nodes/Move.hpp"
 
 #include "geometry_msgs/msg/pose2_d.hpp"
-#include "tf2_geometry_msgs/tf2_geometry_msgs.h"
+#include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
 
 #include "behaviortree_cpp_v3/behavior_tree.h"
 
@@ -35,7 +35,7 @@ Move::Move(
   const BT::NodeConfiguration & conf)
 : plansys2::BtActionNode<nav2_msgs::action::NavigateToPose>(xml_tag_name, action_name, conf)
 {
-  rclcpp::Node::SharedPtr node;
+  rclcpp_lifecycle::LifecycleNode::SharedPtr node;
   config().blackboard->get("node", node);
 
   try {
@@ -75,7 +75,7 @@ BT::NodeStatus
 Move::on_tick()
 {
   if (status() == BT::NodeStatus::IDLE) {
-    rclcpp::Node::SharedPtr node;
+    rclcpp_lifecycle::LifecycleNode::SharedPtr node;
     config().blackboard->get("node", node);
 
     std::string goal;

--- a/plansys2_bt_example/src/nav2_sim_node.cpp
+++ b/plansys2_bt_example/src/nav2_sim_node.cpp
@@ -17,7 +17,7 @@
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_action/rclcpp_action.hpp"
 #include "nav2_msgs/action/navigate_to_pose.hpp"
-#include "tf2_geometry_msgs/tf2_geometry_msgs.h"
+#include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
 
 using std::placeholders::_1;
 using std::placeholders::_2;


### PR DESCRIPTION
Hi all,

This PR adapts some actions to https://github.com/PlanSys2/ros2_planning_system/pull/251

It also fixes some deprecation warnings in headers.

Best

Signed-off-by: Francisco Martín Rico <fmrico@gmail.com>