### PR TITLE
Fix instructions Behavior Tree Example

### DIFF
--- a/plansys2_bt_example/README.md
+++ b/plansys2_bt_example/README.md
@@ -32,6 +32,7 @@ In terminal 3:
 ros2 run plansys2_terminal plansys2_terminal
 set instance r2d2 robot
 
+set instance recharge_zone zone
 set instance wheels_zone zone
 set instance steering_wheels_zone zone
 set instance body_car_zone zone
@@ -41,12 +42,14 @@ set instance wheel_1 piece
 set instance body_car_1 piece
 set instance steering_wheel_1 piece
 
+set predicate (robot_available r2d2)
+set predicate (robot_at r2d2 assembly_zone)
+set predicate (is_recharge_zone recharge_zone)
 set predicate (piece_at wheel_1 wheels_zone)
 set predicate (piece_at body_car_1 body_car_zone)
 set predicate (piece_at steering_wheel_1 steering_wheels_zone)
 
-set predicate (robot_at r2d2 assembly_zone)
-
 set goal (and(piece_at wheel_1 assembly_zone))
+
 run
 ```

--- a/plansys2_bt_example/README.md
+++ b/plansys2_bt_example/README.md
@@ -36,6 +36,8 @@ In terminal 3:
 ros2 run plansys2_terminal plansys2_terminal
 ```
 
+Enter it manually, line by line:
+
 ```text
 set instance r2d2 robot
 
@@ -59,4 +61,9 @@ set predicate (piece_at steering_wheel_1 steering_wheels_zone)
 set goal (and(piece_at wheel_1 assembly_zone))
 
 run
+```
+Or, paste commands above into a file (e.g. commands.txt), start the plansys2_terminal and enter the following:
+
+```text
+source commands.txt
 ```

--- a/plansys2_bt_example/README.md
+++ b/plansys2_bt_example/README.md
@@ -12,8 +12,11 @@ See https://github.com/IntelligentRoboticsLabs/ros2_planning_system/pull/27 for 
 
 In terminal 1:
 
-```
-ros2 launch nav2_bringup tb3_simulation_launch.py
+```bash
+export GAZEBO_MODEL_PATH=$GAZEBO_MODEL_PATH:/opt/ros/humble/share/turtlebot3_gazebo/models
+export TURTLEBOT3_MODEL=waffle
+source /usr/share/gazebo/setup.sh
+ros2 launch nav2_bringup tb3_simulation_launch.py headless:=False
 ```
 
 This launches Navigation2. Use rviz to set the robot position, as shown here:
@@ -22,14 +25,18 @@ This launches Navigation2. Use rviz to set the robot position, as shown here:
 
 In terminal 2:
 
-```
+```bash
+source $HOME/dev_ws/install/setup.bash
 ros2 launch plansys2_bt_example plansys2_bt_example_launch.py
 ```
 
 In terminal 3:
 
-```
+```bash
 ros2 run plansys2_terminal plansys2_terminal
+```
+
+```text
 set instance r2d2 robot
 
 set instance recharge_zone zone

--- a/plansys2_bt_example/README.md
+++ b/plansys2_bt_example/README.md
@@ -32,6 +32,8 @@ ros2 launch plansys2_bt_example plansys2_bt_example_launch.py
 
 In terminal 3:
 
+There are two options in this example. First option is to use the plansys2 terminal. Secondly you can use the custom assemble controller. Both options are shown below.
+
 ```bash
 ros2 run plansys2_terminal plansys2_terminal
 ```
@@ -62,8 +64,14 @@ set goal (and(piece_at wheel_1 assembly_zone))
 
 run
 ```
-Or, paste commands above into a file (e.g. commands.txt), start the plansys2_terminal and enter the following:
+You can also paste commands above into a file (e.g. commands.txt), start the plansys2_terminal and enter the following:
 
 ```text
 source commands.txt
 ```
+Or use a custom controller:
+
+```bash
+$HOME/dev_ws/build/plansys2_bt_example/assemble_controller_node
+```
+NOTE: this problem domain is different from example entered in the plansys2 terminal.


### PR DESCRIPTION
The PlanSys2 Behavior Tree Example still wasn't working for me.
- fix ps2 terminal commands
- added instructions to source commands.txt in ps2 terminal
- added instructions for running the c++ assemble controller (I could not find any documentation)