### PR TITLE
Fix instructions Behavior Tree Example

### DIFF
--- a/plansys2_bt_example/README.md
+++ b/plansys2_bt_example/README.md
@@ -32,6 +32,7 @@ In terminal 3:
 ros2 run plansys2_terminal plansys2_terminal
 set instance r2d2 robot
 
+set instance recharge_zone zone
 set instance wheels_zone zone
 set instance steering_wheels_zone zone
 set instance body_car_zone zone
@@ -41,12 +42,14 @@ set instance wheel_1 piece
 set instance body_car_1 piece
 set instance steering_wheel_1 piece
 
+set predicate (robot_available r2d2)
+set predicate (robot_at r2d2 assembly_zone)
+set predicate (is_recharge_zone recharge_zone)
 set predicate (piece_at wheel_1 wheels_zone)
 set predicate (piece_at body_car_1 body_car_zone)
 set predicate (piece_at steering_wheel_1 steering_wheels_zone)
 
-set predicate (robot_at r2d2 assembly_zone)
-
 set goal (and(piece_at wheel_1 assembly_zone))
+
 run
 ```

--- a/plansys2_bt_example/README.md
+++ b/plansys2_bt_example/README.md
@@ -36,6 +36,8 @@ In terminal 3:
 ros2 run plansys2_terminal plansys2_terminal
 ```
 
+Enter it manually, line by line:
+
 ```text
 set instance r2d2 robot
 
@@ -59,4 +61,9 @@ set predicate (piece_at steering_wheel_1 steering_wheels_zone)
 set goal (and(piece_at wheel_1 assembly_zone))
 
 run
+```
+Or, paste commands above into a file (e.g. commands.txt), start the plansys2_terminal and enter the following:
+
+```text
+source commands.txt
 ```

--- a/plansys2_bt_example/README.md
+++ b/plansys2_bt_example/README.md
@@ -12,8 +12,11 @@ See https://github.com/IntelligentRoboticsLabs/ros2_planning_system/pull/27 for 
 
 In terminal 1:
 
-```
-ros2 launch nav2_bringup tb3_simulation_launch.py
+```bash
+export GAZEBO_MODEL_PATH=$GAZEBO_MODEL_PATH:/opt/ros/humble/share/turtlebot3_gazebo/models
+export TURTLEBOT3_MODEL=waffle
+source /usr/share/gazebo/setup.sh
+ros2 launch nav2_bringup tb3_simulation_launch.py headless:=False
 ```
 
 This launches Navigation2. Use rviz to set the robot position, as shown here:
@@ -22,14 +25,18 @@ This launches Navigation2. Use rviz to set the robot position, as shown here:
 
 In terminal 2:
 
-```
+```bash
+source $HOME/dev_ws/install/setup.bash
 ros2 launch plansys2_bt_example plansys2_bt_example_launch.py
 ```
 
 In terminal 3:
 
-```
+```bash
 ros2 run plansys2_terminal plansys2_terminal
+```
+
+```text
 set instance r2d2 robot
 
 set instance recharge_zone zone

--- a/plansys2_bt_example/README.md
+++ b/plansys2_bt_example/README.md
@@ -10,12 +10,13 @@ See https://github.com/IntelligentRoboticsLabs/ros2_planning_system/pull/27 for 
 
 ## How to run
 
-In terminal 1:
+### In terminal 1:
 
 ```bash
 export GAZEBO_MODEL_PATH=$GAZEBO_MODEL_PATH:/opt/ros/humble/share/turtlebot3_gazebo/models
 export TURTLEBOT3_MODEL=waffle
 source /usr/share/gazebo/setup.sh
+source $HOME/dev_ws/install/setup.bash
 ros2 launch nav2_bringup tb3_simulation_launch.py headless:=False
 ```
 
@@ -23,18 +24,28 @@ This launches Navigation2. Use rviz to set the robot position, as shown here:
 
  ![nav2 start](nav2_init.png)
 
-In terminal 2:
+Or use the commandline (e.g. in terminal 2):
+```bash
+ros2 topic pub --once /initialpose geometry_msgs/msg/PoseWithCovarianceStamped "{header: {stamp: {sec: 0, nanosec: 0}, frame_id: 'map'}, pose:{pose: {position: {x: -2.0, y: -0.5, z: 0.01}, orientation: {x: 0.0, y: 0.0, z: 0.0, w: 1.0}}}}"
+```
+
+### In terminal 2:
 
 ```bash
 source $HOME/dev_ws/install/setup.bash
 ros2 launch plansys2_bt_example plansys2_bt_example_launch.py
 ```
 
-In terminal 3:
+### In terminal 3:
 
 There are two options in this example. First option is to use the plansys2 terminal. Secondly you can use the custom assemble controller. Both options are shown below.
 
 ```bash
+source $HOME/dev_ws/install/setup.bash
+
+# before you run the commands below, it seems the starting location must be different to prevent an error
+ros2 topic pub --times 3 /goal_pose geometry_msgs/PoseStamped "{header: {stamp: {sec: 0}, frame_id: 'map'}, pose: {position: {x: -0.4, y: 0.4, z: 0.01}, orientation: {w: 0.0}}}"
+
 ros2 run plansys2_terminal plansys2_terminal
 ```
 
@@ -42,26 +53,21 @@ Enter it manually, line by line:
 
 ```text
 set instance r2d2 robot
-
 set instance recharge_zone zone
 set instance wheels_zone zone
 set instance steering_wheels_zone zone
 set instance body_car_zone zone
 set instance assembly_zone zone
-
 set instance wheel_1 piece
 set instance body_car_1 piece
 set instance steering_wheel_1 piece
-
 set predicate (robot_available r2d2)
 set predicate (robot_at r2d2 assembly_zone)
 set predicate (is_recharge_zone recharge_zone)
 set predicate (piece_at wheel_1 wheels_zone)
 set predicate (piece_at body_car_1 body_car_zone)
 set predicate (piece_at steering_wheel_1 steering_wheels_zone)
-
 set goal (and(piece_at wheel_1 assembly_zone))
-
 run
 ```
 You can also paste commands above into a file (e.g. commands.txt), start the plansys2_terminal and enter the following:
@@ -72,6 +78,7 @@ source commands.txt
 Or use a custom controller:
 
 ```bash
+source $HOME/dev_ws/install/setup.bash
 $HOME/dev_ws/build/plansys2_bt_example/assemble_controller_node
 ```
 NOTE: this problem domain is different from example entered in the plansys2 terminal.

--- a/plansys2_bt_example/README.md
+++ b/plansys2_bt_example/README.md
@@ -32,6 +32,8 @@ ros2 launch plansys2_bt_example plansys2_bt_example_launch.py
 
 In terminal 3:
 
+There are two options in this example. First option is to use the plansys2 terminal. Secondly you can use the custom assemble controller. Both options are shown below.
+
 ```bash
 ros2 run plansys2_terminal plansys2_terminal
 ```
@@ -62,8 +64,14 @@ set goal (and(piece_at wheel_1 assembly_zone))
 
 run
 ```
-Or, paste commands above into a file (e.g. commands.txt), start the plansys2_terminal and enter the following:
+You can also paste commands above into a file (e.g. commands.txt), start the plansys2_terminal and enter the following:
 
 ```text
 source commands.txt
 ```
+Or use a custom controller:
+
+```bash
+$HOME/dev_ws/build/plansys2_bt_example/assemble_controller_node
+```
+NOTE: this problem domain is different from example entered in the plansys2 terminal.


### PR DESCRIPTION
Attempt no.2

The PlanSys2 Behavior Tree Example still wasn't working for me.

- fix ps2 terminal commands
- added cli option to set initial pose (in stead of using rviz)
- move robot to other starting position using cli to prevent error (see below)
- added instructions to source commands.txt in ps2 terminal
- added instructions for running the c++ assemble controller (I could not find any documentation)

About the error. When I don't move the turtlebot to different starting position, I get this error:
```text
(...)
[bt_action_node-4] [INFO] [1691235883.147913359] [move_3]: "move" BtActionNode initialized
[bt_action_node-4] [INFO] [1691235883.349717179] [move_3]: Missing input port [server_timeout], using default value of 5s
[bt_action_node-4] [INFO] [1691235883.354744945] [move_3]: Waiting for "navigate_to_pose" action server
[bt_action_node-4] [INFO] [1691235883.355204436] [move_3]: Sending goal to action server navigate_to_pose
[ERROR] [bt_action_node-4]: process has died [pid 43380, exit code -11, cmd '/home/USER/dev_ws/install/plansys2_bt_actions/lib/plansys2_bt_actions/bt_action_node --ros-args -r __node:=move_3 -r __ns:=/ --params-file /home/USER/dev_ws/install/plansys2_bt_example/share/plansys2_bt_example/config/params.yaml --params-file /tmp/launch_params_oc30dur0'].
(...)
```
I suspect an issue in the bt action node (move), but I might be doing something wrong.