### PR TITLE
Upgrade examples to Behaviortree.CPP v4.x in Plansys2 

### DIFF
--- a/plansys2_bt_example/behavior_trees_xml/move.xml
+++ b/plansys2_bt_example/behavior_trees_xml/move.xml
@@ -1,4 +1,4 @@
-<root main_tree_to_execute = "MainTree" >
+<root BTCPP_format = "4" main_tree_to_execute = "MainTree" >
     <BehaviorTree ID="MainTree">
        <Sequence name="root_sequence">
            <Move    name="move" goal="${arg2}"/>

--- a/plansys2_bt_example/behavior_trees_xml/recharge.xml
+++ b/plansys2_bt_example/behavior_trees_xml/recharge.xml
@@ -1,4 +1,4 @@
-<root main_tree_to_execute = "MainTree" >
+<root BTCPP_format = "4" main_tree_to_execute = "MainTree" >
     <BehaviorTree ID="MainTree">
        <Sequence name="root_sequence">
            <Recharge    name="recharge"/>

--- a/plansys2_bt_example/behavior_trees_xml/transport.xml
+++ b/plansys2_bt_example/behavior_trees_xml/transport.xml
@@ -1,4 +1,4 @@
-<root main_tree_to_execute = "MainTree" >
+<root BTCPP_format = "4" main_tree_to_execute = "MainTree" >
     <BehaviorTree ID="MainTree">
        <Sequence name="root_sequence">
            <OpenGripper    name="open_gripper"/>

--- a/plansys2_bt_example/include/plansys2_bt_example/behavior_tree_nodes/ApproachObject.hpp
+++ b/plansys2_bt_example/include/plansys2_bt_example/behavior_tree_nodes/ApproachObject.hpp
@@ -17,8 +17,8 @@
 
 #include <string>
 
-#include "behaviortree_cpp_v3/behavior_tree.h"
-#include "behaviortree_cpp_v3/bt_factory.h"
+#include "behaviortree_cpp/behavior_tree.h"
+#include "behaviortree_cpp/bt_factory.h"
 
 namespace plansys2_bt_example
 {

--- a/plansys2_bt_example/include/plansys2_bt_example/behavior_tree_nodes/ApproachObject.hpp
+++ b/plansys2_bt_example/include/plansys2_bt_example/behavior_tree_nodes/ApproachObject.hpp
@@ -28,7 +28,7 @@ class ApproachObject : public BT::ActionNodeBase
 public:
   explicit ApproachObject(
     const std::string & xml_tag_name,
-    const BT::NodeConfiguration & conf);
+    const BT::NodeConfig & conf);
 
   void halt();
   BT::NodeStatus tick();

--- a/plansys2_bt_example/include/plansys2_bt_example/behavior_tree_nodes/CloseGripper.hpp
+++ b/plansys2_bt_example/include/plansys2_bt_example/behavior_tree_nodes/CloseGripper.hpp
@@ -28,7 +28,7 @@ class CloseGripper : public BT::ActionNodeBase
 public:
   explicit CloseGripper(
     const std::string & xml_tag_name,
-    const BT::NodeConfiguration & conf);
+    const BT::NodeConfig & conf);
 
   void halt();
   BT::NodeStatus tick();

--- a/plansys2_bt_example/include/plansys2_bt_example/behavior_tree_nodes/CloseGripper.hpp
+++ b/plansys2_bt_example/include/plansys2_bt_example/behavior_tree_nodes/CloseGripper.hpp
@@ -17,8 +17,8 @@
 
 #include <string>
 
-#include "behaviortree_cpp_v3/behavior_tree.h"
-#include "behaviortree_cpp_v3/bt_factory.h"
+#include "behaviortree_cpp/behavior_tree.h"
+#include "behaviortree_cpp/bt_factory.h"
 
 namespace plansys2_bt_example
 {

--- a/plansys2_bt_example/include/plansys2_bt_example/behavior_tree_nodes/Move.hpp
+++ b/plansys2_bt_example/include/plansys2_bt_example/behavior_tree_nodes/Move.hpp
@@ -35,7 +35,7 @@ public:
   explicit Move(
     const std::string & xml_tag_name,
     const std::string & action_name,
-    const BT::NodeConfiguration & conf);
+    const BT::NodeConfig & conf);
 
   BT::NodeStatus on_tick() override;
   BT::NodeStatus on_success() override;

--- a/plansys2_bt_example/include/plansys2_bt_example/behavior_tree_nodes/Move.hpp
+++ b/plansys2_bt_example/include/plansys2_bt_example/behavior_tree_nodes/Move.hpp
@@ -22,8 +22,8 @@
 #include "nav2_msgs/action/navigate_to_pose.hpp"
 
 #include "plansys2_bt_actions/BTActionNode.hpp"
-#include "behaviortree_cpp_v3/behavior_tree.h"
-#include "behaviortree_cpp_v3/bt_factory.h"
+#include "behaviortree_cpp/behavior_tree.h"
+#include "behaviortree_cpp/bt_factory.h"
 
 namespace plansys2_bt_tests
 {

--- a/plansys2_bt_example/include/plansys2_bt_example/behavior_tree_nodes/OpenGripper.hpp
+++ b/plansys2_bt_example/include/plansys2_bt_example/behavior_tree_nodes/OpenGripper.hpp
@@ -28,7 +28,7 @@ class OpenGripper : public BT::ActionNodeBase
 public:
   explicit OpenGripper(
     const std::string & xml_tag_name,
-    const BT::NodeConfiguration & conf);
+    const BT::NodeConfig & conf);
 
   void halt();
   BT::NodeStatus tick();

--- a/plansys2_bt_example/include/plansys2_bt_example/behavior_tree_nodes/OpenGripper.hpp
+++ b/plansys2_bt_example/include/plansys2_bt_example/behavior_tree_nodes/OpenGripper.hpp
@@ -17,8 +17,8 @@
 
 #include <string>
 
-#include "behaviortree_cpp_v3/behavior_tree.h"
-#include "behaviortree_cpp_v3/bt_factory.h"
+#include "behaviortree_cpp/behavior_tree.h"
+#include "behaviortree_cpp/bt_factory.h"
 
 namespace plansys2_bt_example
 {

--- a/plansys2_bt_example/include/plansys2_bt_example/behavior_tree_nodes/Recharge.hpp
+++ b/plansys2_bt_example/include/plansys2_bt_example/behavior_tree_nodes/Recharge.hpp
@@ -28,7 +28,7 @@ class Recharge : public BT::ActionNodeBase
 public:
   explicit Recharge(
     const std::string & xml_tag_name,
-    const BT::NodeConfiguration & conf);
+    const BT::NodeConfig & conf);
 
   void halt();
   BT::NodeStatus tick();

--- a/plansys2_bt_example/include/plansys2_bt_example/behavior_tree_nodes/Recharge.hpp
+++ b/plansys2_bt_example/include/plansys2_bt_example/behavior_tree_nodes/Recharge.hpp
@@ -17,8 +17,8 @@
 
 #include <string>
 
-#include "behaviortree_cpp_v3/behavior_tree.h"
-#include "behaviortree_cpp_v3/bt_factory.h"
+#include "behaviortree_cpp/behavior_tree.h"
+#include "behaviortree_cpp/bt_factory.h"
 
 namespace plansys2_bt_example
 {

--- a/plansys2_bt_example/launch/plansys2_bt_example_launch.py
+++ b/plansys2_bt_example/launch/plansys2_bt_example_launch.py
@@ -54,7 +54,6 @@ def generate_launch_description():
           example_dir + '/config/params.yaml',
           {
             'action_name': 'move',
-            'publisher_port': 1668,
             'server_port': 1669,
             'bt_xml_file': example_dir + '/behavior_trees_xml/move.xml'
           }
@@ -70,7 +69,6 @@ def generate_launch_description():
           example_dir + '/config/params.yaml',
           {
             'action_name': 'move',
-            'publisher_port': 1670,
             'server_port': 1671,
             'bt_xml_file': example_dir + '/behavior_trees_xml/move.xml'
           }
@@ -86,7 +84,6 @@ def generate_launch_description():
           example_dir + '/config/params.yaml',
           {
             'action_name': 'move',
-            'publisher_port': 1672,
             'server_port': 1673,
             'bt_xml_file': example_dir + '/behavior_trees_xml/move.xml'
           }
@@ -102,7 +99,6 @@ def generate_launch_description():
           example_dir + '/config/params.yaml',
           {
             'action_name': 'transport',
-            'publisher_port': 1674,
             'server_port': 1675,
             'bt_xml_file': example_dir + '/behavior_trees_xml/transport.xml'
           }
@@ -117,7 +113,6 @@ def generate_launch_description():
           example_dir + '/config/params.yaml',
           {
             'action_name': 'transport',
-            'publisher_port': 1676,
             'server_port': 1677,
             'bt_xml_file': example_dir + '/behavior_trees_xml/transport.xml'
           }
@@ -132,7 +127,6 @@ def generate_launch_description():
           example_dir + '/config/params.yaml',
           {
             'action_name': 'transport',
-            'publisher_port': 1678,
             'server_port': 1679,
             'bt_xml_file': example_dir + '/behavior_trees_xml/transport.xml'
           }

--- a/plansys2_bt_example/src/behavior_tree_nodes/ApproachObject.cpp
+++ b/plansys2_bt_example/src/behavior_tree_nodes/ApproachObject.cpp
@@ -24,7 +24,7 @@ namespace plansys2_bt_example
 
 ApproachObject::ApproachObject(
   const std::string & xml_tag_name,
-  const BT::NodeConfiguration & conf)
+  const BT::NodeConfig & conf)
 : BT::ActionNodeBase(xml_tag_name, conf), counter_(0)
 {
 }

--- a/plansys2_bt_example/src/behavior_tree_nodes/ApproachObject.cpp
+++ b/plansys2_bt_example/src/behavior_tree_nodes/ApproachObject.cpp
@@ -17,7 +17,7 @@
 
 #include "plansys2_bt_example/behavior_tree_nodes/ApproachObject.hpp"
 
-#include "behaviortree_cpp_v3/behavior_tree.h"
+#include "behaviortree_cpp/behavior_tree.h"
 
 namespace plansys2_bt_example
 {
@@ -50,7 +50,7 @@ ApproachObject::tick()
 
 }  // namespace plansys2_bt_example
 
-#include "behaviortree_cpp_v3/bt_factory.h"
+#include "behaviortree_cpp/bt_factory.h"
 BT_REGISTER_NODES(factory)
 {
   factory.registerNodeType<plansys2_bt_example::ApproachObject>("ApproachObject");

--- a/plansys2_bt_example/src/behavior_tree_nodes/CloseGripper.cpp
+++ b/plansys2_bt_example/src/behavior_tree_nodes/CloseGripper.cpp
@@ -24,7 +24,7 @@ namespace plansys2_bt_example
 
 CloseGripper::CloseGripper(
   const std::string & xml_tag_name,
-  const BT::NodeConfiguration & conf)
+  const BT::NodeConfig & conf)
 : BT::ActionNodeBase(xml_tag_name, conf), counter_(0)
 {
 }

--- a/plansys2_bt_example/src/behavior_tree_nodes/CloseGripper.cpp
+++ b/plansys2_bt_example/src/behavior_tree_nodes/CloseGripper.cpp
@@ -17,7 +17,7 @@
 
 #include "plansys2_bt_example/behavior_tree_nodes/CloseGripper.hpp"
 
-#include "behaviortree_cpp_v3/behavior_tree.h"
+#include "behaviortree_cpp/behavior_tree.h"
 
 namespace plansys2_bt_example
 {
@@ -50,7 +50,7 @@ CloseGripper::tick()
 
 }  // namespace plansys2_bt_example
 
-#include "behaviortree_cpp_v3/bt_factory.h"
+#include "behaviortree_cpp/bt_factory.h"
 BT_REGISTER_NODES(factory)
 {
   factory.registerNodeType<plansys2_bt_example::CloseGripper>("CloseGripper");

--- a/plansys2_bt_example/src/behavior_tree_nodes/Move.cpp
+++ b/plansys2_bt_example/src/behavior_tree_nodes/Move.cpp
@@ -22,7 +22,7 @@
 #include "geometry_msgs/msg/pose2_d.hpp"
 #include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
 
-#include "behaviortree_cpp_v3/behavior_tree.h"
+#include "behaviortree_cpp/behavior_tree.h"
 
 #include "rclcpp_lifecycle/lifecycle_node.hpp"
 
@@ -112,7 +112,7 @@ Move::on_success()
 
 }  // namespace plansys2_bt_tests
 
-#include "behaviortree_cpp_v3/bt_factory.h"
+#include "behaviortree_cpp/bt_factory.h"
 BT_REGISTER_NODES(factory)
 {
   BT::NodeBuilder builder =

--- a/plansys2_bt_example/src/behavior_tree_nodes/Move.cpp
+++ b/plansys2_bt_example/src/behavior_tree_nodes/Move.cpp
@@ -32,7 +32,7 @@ namespace plansys2_bt_tests
 Move::Move(
   const std::string & xml_tag_name,
   const std::string & action_name,
-  const BT::NodeConfiguration & conf)
+  const BT::NodeConfig & conf)
 : plansys2::BtActionNode<nav2_msgs::action::NavigateToPose>(xml_tag_name, action_name, conf)
 {
   rclcpp_lifecycle::LifecycleNode::SharedPtr node;
@@ -116,7 +116,7 @@ Move::on_success()
 BT_REGISTER_NODES(factory)
 {
   BT::NodeBuilder builder =
-    [](const std::string & name, const BT::NodeConfiguration & config)
+    [](const std::string & name, const BT::NodeConfig & config)
     {
       return std::make_unique<plansys2_bt_tests::Move>(
         name, "navigate_to_pose", config);

--- a/plansys2_bt_example/src/behavior_tree_nodes/OpenGripper.cpp
+++ b/plansys2_bt_example/src/behavior_tree_nodes/OpenGripper.cpp
@@ -24,7 +24,7 @@ namespace plansys2_bt_example
 
 OpenGripper::OpenGripper(
   const std::string & xml_tag_name,
-  const BT::NodeConfiguration & conf)
+  const BT::NodeConfig & conf)
 : BT::ActionNodeBase(xml_tag_name, conf), counter_(0)
 {
 }

--- a/plansys2_bt_example/src/behavior_tree_nodes/OpenGripper.cpp
+++ b/plansys2_bt_example/src/behavior_tree_nodes/OpenGripper.cpp
@@ -17,7 +17,7 @@
 
 #include "plansys2_bt_example/behavior_tree_nodes/OpenGripper.hpp"
 
-#include "behaviortree_cpp_v3/behavior_tree.h"
+#include "behaviortree_cpp/behavior_tree.h"
 
 namespace plansys2_bt_example
 {
@@ -50,7 +50,7 @@ OpenGripper::tick()
 
 }  // namespace plansys2_bt_example
 
-#include "behaviortree_cpp_v3/bt_factory.h"
+#include "behaviortree_cpp/bt_factory.h"
 BT_REGISTER_NODES(factory)
 {
   factory.registerNodeType<plansys2_bt_example::OpenGripper>("OpenGripper");

--- a/plansys2_bt_example/src/behavior_tree_nodes/Recharge.cpp
+++ b/plansys2_bt_example/src/behavior_tree_nodes/Recharge.cpp
@@ -17,7 +17,7 @@
 
 #include "plansys2_bt_example/behavior_tree_nodes/Recharge.hpp"
 
-#include "behaviortree_cpp_v3/behavior_tree.h"
+#include "behaviortree_cpp/behavior_tree.h"
 
 namespace plansys2_bt_example
 {
@@ -50,7 +50,7 @@ Recharge::tick()
 
 }  // namespace plansys2_bt_example
 
-#include "behaviortree_cpp_v3/bt_factory.h"
+#include "behaviortree_cpp/bt_factory.h"
 BT_REGISTER_NODES(factory)
 {
   factory.registerNodeType<plansys2_bt_example::Recharge>("Recharge");

--- a/plansys2_bt_example/src/behavior_tree_nodes/Recharge.cpp
+++ b/plansys2_bt_example/src/behavior_tree_nodes/Recharge.cpp
@@ -24,7 +24,7 @@ namespace plansys2_bt_example
 
 Recharge::Recharge(
   const std::string & xml_tag_name,
-  const BT::NodeConfiguration & conf)
+  const BT::NodeConfig & conf)
 : BT::ActionNodeBase(xml_tag_name, conf), counter_(0)
 {
 }


### PR DESCRIPTION
The changes made are mainly refactorings in the include sections from `behaviortree_cpp_v3` to `behaviortree_cpp`. 

Also, in BT.4x there was a refactoring between `BT::NodeConfiguration` to `BT::NodeConfig`, and I adapted the code.

In addition, in bt xmls such as `move.xml` or `recharge.xml` I added the `BTCPP_format` attribute to the `<root>` tag, as indicated in the [(BT Documentation)](https://www.behaviortree.dev/docs/migration#xml). By quoting the documentation:

> This will allow us to be compatible with both versions 3 and 4 (in future releases, not yet)

In addition, I removed the `publisher_port` parameter passed to the action nodes in the `plansys2_bt_example` launch file, since using `BT::Groot2Publisher` the publisher parameter was removed, retaining only the server parameter.