### PR TITLE
Fix CI in rolling branch

### DIFF
--- a/.github/workflows/plansys2_bt_example.yaml
+++ b/.github/workflows/plansys2_bt_example.yaml
@@ -15,14 +15,14 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04]
+        os: [ubuntu-24.04]
       fail-fast: false
     steps:
       - name: Install popf deps
         run: sudo apt-get install libfl-dev
       - uses: actions/checkout@v2
       - name: Setup ROS 2
-        uses: ros-tooling/setup-ros@0.7.3
+        uses: ros-tooling/setup-ros@0.7.5
         with:
           required-ros-distributions: rolling
       - name: Install BT.CPP v4 and test_msgs (provisional Fix)
@@ -30,7 +30,7 @@ jobs:
       - name: Rosdep update
         run: rosdep update
       - name: build and test
-        uses: ros-tooling/action-ros-ci@0.3.7
+        uses: ros-tooling/action-ros-ci@0.3.13
         with:
           package-name: plansys2_bt_example
           target-ros2-distro: rolling

--- a/.github/workflows/plansys2_cascade_example.yaml
+++ b/.github/workflows/plansys2_cascade_example.yaml
@@ -15,20 +15,20 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04]
+        os: [ubuntu-24.04]
       fail-fast: false
     steps:
       - name: Install popf deps
         run: sudo apt-get install libfl-dev
       - uses: actions/checkout@v2
       - name: Setup ROS 2
-        uses: ros-tooling/setup-ros@0.7.1
+        uses: ros-tooling/setup-ros@0.7.5
         with:
           required-ros-distributions: rolling
       - name: Install BT.CPP v4 and test_msgs (provisional Fix)
         run: sudo apt-get install ros-rolling-behaviortree-cpp ros-rolling-test-msgs
       - name: build and test
-        uses: ros-tooling/action-ros-ci@0.3.6
+        uses: ros-tooling/action-ros-ci@0.3.13
         with:
           package-name: plansys2_cascade_example
           target-ros2-distro: rolling

--- a/.github/workflows/plansys2_multidomain_example.yaml
+++ b/.github/workflows/plansys2_multidomain_example.yaml
@@ -15,20 +15,20 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04]
+        os: [ubuntu-24.04]
       fail-fast: false
     steps:
       - name: Install popf deps
         run: sudo apt-get install libfl-dev
       - uses: actions/checkout@v2
       - name: Setup ROS 2
-        uses: ros-tooling/setup-ros@0.7.1
+        uses: ros-tooling/setup-ros@0.7.5
         with:
           required-ros-distributions: rolling
       - name: Install BT.CPP v4 and test_msgs (provisional Fix)
         run: sudo apt-get install ros-rolling-behaviortree-cpp ros-rolling-test-msgs
       - name: build and test
-        uses: ros-tooling/action-ros-ci@0.3.6
+        uses: ros-tooling/action-ros-ci@0.3.13
         with:
           package-name: plansys2_multidomain_example
           target-ros2-distro: rolling

--- a/.github/workflows/plansys2_patrol_navigation_example.yaml
+++ b/.github/workflows/plansys2_patrol_navigation_example.yaml
@@ -15,14 +15,14 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04]
+        os: [ubuntu-24.04]
       fail-fast: false
     steps:
       - name: Install popf deps
         run: sudo apt-get install libfl-dev
       - uses: actions/checkout@v2
       - name: Setup ROS 2
-        uses: ros-tooling/setup-ros@0.7.3
+        uses: ros-tooling/setup-ros@0.7.5
         with:
           required-ros-distributions: rolling
       - name: Install BT.CPP v4 and test_msgs (provisional Fix)
@@ -30,7 +30,7 @@ jobs:
       - name: Rosdep update
         run: rosdep update
       - name: build and test
-        uses: ros-tooling/action-ros-ci@0.3.7
+        uses: ros-tooling/action-ros-ci@0.3.13
         with:
           package-name: plansys2_patrol_navigation_example
           target-ros2-distro: rolling

--- a/.github/workflows/plansys2_simple_example.yaml
+++ b/.github/workflows/plansys2_simple_example.yaml
@@ -15,20 +15,20 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04]
+        os: [ubuntu-24.04]
       fail-fast: false
     steps:
       - name: Install popf deps
         run: sudo apt-get install libfl-dev
       - uses: actions/checkout@v2
       - name: Setup ROS 2
-        uses: ros-tooling/setup-ros@0.7.1
+        uses: ros-tooling/setup-ros@0.7.5
         with:
           required-ros-distributions: rolling
       - name: Install BT.CPP v4 and test_msgs (provisional Fix)
         run: sudo apt-get install ros-rolling-behaviortree-cpp ros-rolling-test-msgs
       - name: build and test
-        uses: ros-tooling/action-ros-ci@0.3.6
+        uses: ros-tooling/action-ros-ci@0.3.13
         with:
           package-name: plansys2_simple_example
           target-ros2-distro: rolling


### PR DESCRIPTION
I saw the CI actions were disabled, and after turning them back on in my fork they were failing...
This PR fixes the CI again by upgrading the Ubuntu version to 24.04 and bumping the version of the ros-tooling actions.


If the CI was disabled for some other reason feel free to ignore this.