### PR TITLE
Use geometry pose

### DIFF
--- a/plansys2_bt_example/CMakeLists.txt
+++ b/plansys2_bt_example/CMakeLists.txt
@@ -17,24 +17,22 @@ find_package(plansys2_pddl_parser REQUIRED)
 find_package(ament_index_cpp REQUIRED)
 find_package(plansys2_bt_actions REQUIRED)
 
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 17)
-endif()
+
 
 set(dependencies
-    rclcpp
-    rclcpp_action
-    geometry_msgs
-    tf2_geometry_msgs
-    nav2_msgs
-    plansys2_msgs
-    plansys2_domain_expert
-    plansys2_executor
-    plansys2_planner
-    plansys2_problem_expert
-    plansys2_pddl_parser
-    ament_index_cpp
-    plansys2_bt_actions
+    rclcpp::rclcpp
+    rclcpp_action::rclcpp_action
+    plansys2_domain_expert::plansys2_domain_expert
+    plansys2_executor::plansys2_executor
+    plansys2_planner::plansys2_planner
+    plansys2_problem_expert::plansys2_problem_expert
+    plansys2_pddl_parser::plansys2_pddl_parser
+    ament_index_cpp::ament_index_cpp
+    plansys2_bt_actions::plansys2_bt_actions
+    ${geometry_msgs_TARGETS}
+    ${tf2_geometry_msgs_TARGETS}
+    ${nav2_msgs_TARGETS}
+    ${plansys2_msgs_TARGETS}
 )
 
 include_directories(include)
@@ -55,18 +53,18 @@ add_library(plansys2_approach_object_bt_node SHARED src/behavior_tree_nodes/Appr
 list(APPEND plugin_libs plansys2_approach_object_bt_node)
 
 foreach(bt_plugin ${plugin_libs})
-  ament_target_dependencies(${bt_plugin} ${dependencies})
+  target_link_libraries(${bt_plugin} PUBLIC ${dependencies})
   target_compile_definitions(${bt_plugin} PRIVATE BT_PLUGIN_EXPORT)
 endforeach()
 
 add_executable(assemble_action_node src/assemble_action_node.cpp)
-ament_target_dependencies(assemble_action_node ${dependencies})
+target_link_libraries(assemble_action_node PUBLIC ${dependencies})
 
 add_executable(assemble_controller_node src/assemble_controller_node.cpp)
-ament_target_dependencies(assemble_controller_node ${dependencies})
+target_link_libraries(assemble_controller_node PUBLIC ${dependencies})
 
 add_executable(nav2_sim_node src/nav2_sim_node.cpp)
-ament_target_dependencies(nav2_sim_node ${dependencies})
+target_link_libraries(nav2_sim_node PUBLIC ${dependencies})
 
 install(DIRECTORY launch pddl behavior_trees_xml config DESTINATION share/${PROJECT_NAME})
 
@@ -77,7 +75,7 @@ install(TARGETS
   ${plugin_libs}
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
-  RUNTIME DESTINATION lib/${PROJECT_NAME}
+  RUNTIME DESTINATION bin
 )
 
 if(BUILD_TESTING)
@@ -86,7 +84,5 @@ if(BUILD_TESTING)
 
   find_package(ament_cmake_gtest REQUIRED)
 endif()
-
-ament_export_dependencies(${dependencies})
 
 ament_package()

--- a/plansys2_bt_example/include/plansys2_bt_example/behavior_tree_nodes/Move.hpp
+++ b/plansys2_bt_example/include/plansys2_bt_example/behavior_tree_nodes/Move.hpp
@@ -18,7 +18,7 @@
 #include <string>
 #include <map>
 
-#include "geometry_msgs/msg/pose2_d.hpp"
+#include "geometry_msgs/msg/pose.hpp"
 #include "nav2_msgs/action/navigate_to_pose.hpp"
 
 #include "plansys2_bt_actions/BTActionNode.hpp"
@@ -49,7 +49,7 @@ public:
 
 private:
   int goal_reached_;
-  std::map<std::string, geometry_msgs::msg::Pose2D> waypoints_;
+  std::map<std::string, geometry_msgs::msg::Pose> waypoints_;
 };
 
 }  // namespace plansys2_bt_tests

--- a/plansys2_bt_example/src/assemble_controller_node.cpp
+++ b/plansys2_bt_example/src/assemble_controller_node.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <memory>
+#include <tuple>
 
 #include "plansys2_pddl_parser/Utils.hpp"
 

--- a/plansys2_bt_example/src/behavior_tree_nodes/Move.cpp
+++ b/plansys2_bt_example/src/behavior_tree_nodes/Move.cpp
@@ -19,7 +19,7 @@
 
 #include "plansys2_bt_example/behavior_tree_nodes/Move.hpp"
 
-#include "geometry_msgs/msg/pose2_d.hpp"
+#include "geometry_msgs/msg/pose.hpp"
 #include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
 
 #include "behaviortree_cpp/behavior_tree.h"
@@ -60,10 +60,10 @@ Move::Move(
 
       std::vector<double> coords;
       if (node->get_parameter_or("waypoint_coords." + wp, coords, {})) {
-        geometry_msgs::msg::Pose2D pose;
-        pose.x = coords[0];
-        pose.y = coords[1];
-        pose.theta = coords[2];
+        geometry_msgs::msg::Pose pose;
+        pose.position.x = coords[0];
+        pose.position.y = coords[1];
+        pose.orientation = tf2::toMsg(tf2::Quaternion({0.0, 0.0, 1.0}, coords[2]));
 
         waypoints_[wp] = pose;
       } else {
@@ -85,7 +85,7 @@ Move::on_tick()
     std::string goal;
     getInput<std::string>("goal", goal);
 
-    geometry_msgs::msg::Pose2D pose2nav;
+    geometry_msgs::msg::Pose pose2nav;
     if (waypoints_.find(goal) != waypoints_.end()) {
       pose2nav = waypoints_[goal];
     } else {
@@ -96,10 +96,7 @@ Move::on_tick()
 
     goal_pos.header.frame_id = "map";
     goal_pos.header.stamp = node->now();
-    goal_pos.pose.position.x = pose2nav.x;
-    goal_pos.pose.position.y = pose2nav.y;
-    goal_pos.pose.position.z = 0;
-    goal_pos.pose.orientation = tf2::toMsg(tf2::Quaternion({0.0, 0.0, 1.0}, pose2nav.theta));
+    goal_pos.pose = pose2nav;
 
     goal_.pose = goal_pos;
   }

--- a/plansys2_cascade_example/CMakeLists.txt
+++ b/plansys2_cascade_example/CMakeLists.txt
@@ -8,26 +8,26 @@ find_package(rclcpp_action REQUIRED)
 find_package(plansys2_msgs REQUIRED)
 find_package(plansys2_executor REQUIRED)
 
-set(CMAKE_CXX_STANDARD 17)
+
 
 set(dependencies
-    rclcpp
-    rclcpp_action
-    plansys2_msgs
-    plansys2_executor
+    rclcpp::rclcpp
+    rclcpp_action::rclcpp_action
+    plansys2_executor::plansys2_executor
+    ${plansys2_msgs_TARGETS}
 )
 
 add_executable(move_action_node src/move_action_node.cpp)
-ament_target_dependencies(move_action_node ${dependencies})
+target_link_libraries(move_action_node PUBLIC ${dependencies})
 
 add_executable(charge_action_node src/charge_action_node.cpp)
-ament_target_dependencies(charge_action_node ${dependencies})
+target_link_libraries(charge_action_node PUBLIC ${dependencies})
 
 add_executable(ask_charge_action_node src/ask_charge_action_node.cpp)
-ament_target_dependencies(ask_charge_action_node ${dependencies})
+target_link_libraries(ask_charge_action_node PUBLIC ${dependencies})
 
 add_executable(check_obstacles_node src/check_obstacles_node.cpp)
-ament_target_dependencies(check_obstacles_node ${dependencies})
+target_link_libraries(check_obstacles_node PUBLIC ${dependencies})
 
 install(DIRECTORY launch pddl DESTINATION share/${PROJECT_NAME})
 
@@ -47,7 +47,5 @@ if(BUILD_TESTING)
 
   find_package(ament_cmake_gtest REQUIRED)
 endif()
-
-ament_export_dependencies(${dependencies})
 
 ament_package()

--- a/plansys2_multidomain_example/CMakeLists.txt
+++ b/plansys2_multidomain_example/CMakeLists.txt
@@ -8,29 +8,29 @@ find_package(rclcpp_action REQUIRED)
 find_package(plansys2_msgs REQUIRED)
 find_package(plansys2_executor REQUIRED)
 
-set(CMAKE_CXX_STANDARD 17)
+
 
 set(dependencies
-    rclcpp
-    rclcpp_action
-    plansys2_msgs
-    plansys2_executor
+    rclcpp::rclcpp
+    rclcpp_action::rclcpp_action
+    plansys2_executor::plansys2_executor
+    ${plansys2_msgs_TARGETS}
 )
 
 add_executable(move_action_node src/move_action_node.cpp)
-ament_target_dependencies(move_action_node ${dependencies})
+target_link_libraries(move_action_node PUBLIC ${dependencies})
 
 add_executable(charge_action_node src/charge_action_node.cpp)
-ament_target_dependencies(charge_action_node ${dependencies})
+target_link_libraries(charge_action_node PUBLIC ${dependencies})
 
 add_executable(ask_charge_action_node src/ask_charge_action_node.cpp)
-ament_target_dependencies(ask_charge_action_node ${dependencies})
+target_link_libraries(ask_charge_action_node PUBLIC ${dependencies})
 
 add_executable(pick_object_action_node src/pick_object_action_node.cpp)
-ament_target_dependencies(pick_object_action_node ${dependencies})
+target_link_libraries(pick_object_action_node PUBLIC ${dependencies})
 
 add_executable(place_object_action_node src/place_object_action_node.cpp)
-ament_target_dependencies(place_object_action_node ${dependencies})
+target_link_libraries(place_object_action_node PUBLIC ${dependencies})
 
 install(DIRECTORY launch pddl_1 pddl_2 DESTINATION share/${PROJECT_NAME})
 
@@ -51,7 +51,5 @@ if(BUILD_TESTING)
 
   find_package(ament_cmake_gtest REQUIRED)
 endif()
-
-ament_export_dependencies(${dependencies})
 
 ament_package()

--- a/plansys2_patrol_navigation_example/CMakeLists.txt
+++ b/plansys2_patrol_navigation_example/CMakeLists.txt
@@ -14,28 +14,27 @@ find_package(plansys2_planner REQUIRED)
 find_package(plansys2_problem_expert REQUIRED)
 find_package(plansys2_pddl_parser REQUIRED)
 
-set(CMAKE_CXX_STANDARD 17)
 
 set(dependencies
-    rclcpp
-    rclcpp_action
-    plansys2_msgs
-    nav2_msgs
-    plansys2_domain_expert
-    plansys2_executor
-    plansys2_planner
-    plansys2_problem_expert
-    plansys2_pddl_parser
+    rclcpp::rclcpp
+    rclcpp_action::rclcpp_action
+    plansys2_domain_expert::plansys2_domain_expert
+    plansys2_executor::plansys2_executor
+    plansys2_planner::plansys2_planner
+    plansys2_problem_expert::plansys2_problem_expert
+    plansys2_pddl_parser::plansys2_pddl_parser
+    ${plansys2_msgs_TARGETS}
+    ${nav2_msgs_TARGETS}
 )
 
 add_executable(move_action_node src/move_action_node.cpp)
-ament_target_dependencies(move_action_node ${dependencies})
+target_link_libraries(move_action_node PUBLIC ${dependencies})
 
 add_executable(patrol_action_node src/patrol_action_node.cpp)
-ament_target_dependencies(patrol_action_node ${dependencies})
+target_link_libraries(patrol_action_node PUBLIC ${dependencies})
 
 add_executable(patrolling_controller_node src/patrolling_controller_node.cpp)
-ament_target_dependencies(patrolling_controller_node ${dependencies})
+target_link_libraries(patrolling_controller_node PUBLIC ${dependencies})
 
 install(DIRECTORY launch pddl params DESTINATION share/${PROJECT_NAME})
 
@@ -54,7 +53,5 @@ if(BUILD_TESTING)
 
   find_package(ament_cmake_gtest REQUIRED)
 endif()
-
-ament_export_dependencies(${dependencies})
 
 ament_package()

--- a/plansys2_patrol_navigation_example/src/patrolling_controller_node.cpp
+++ b/plansys2_patrol_navigation_example/src/patrolling_controller_node.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <memory>
+#include <tuple>
 
 #include "plansys2_pddl_parser/Utils.hpp"
 

--- a/plansys2_simple_example/CMakeLists.txt
+++ b/plansys2_simple_example/CMakeLists.txt
@@ -7,22 +7,22 @@ find_package(rclcpp REQUIRED)
 find_package(plansys2_msgs REQUIRED)
 find_package(plansys2_executor REQUIRED)
 
-set(CMAKE_CXX_STANDARD 17)
+
 
 set(dependencies
-    rclcpp
-    plansys2_msgs
-    plansys2_executor
+    rclcpp::rclcpp
+    plansys2_executor::plansys2_executor
+    ${plansys2_msgs_TARGETS}
 )
 
 add_executable(move_action_node src/move_action_node.cpp)
-ament_target_dependencies(move_action_node ${dependencies})
+target_link_libraries(move_action_node PUBLIC ${dependencies})
 
 add_executable(charge_action_node src/charge_action_node.cpp)
-ament_target_dependencies(charge_action_node ${dependencies})
+target_link_libraries(charge_action_node PUBLIC ${dependencies})
 
 add_executable(ask_charge_action_node src/ask_charge_action_node.cpp)
-ament_target_dependencies(ask_charge_action_node ${dependencies})
+target_link_libraries(ask_charge_action_node PUBLIC ${dependencies})
 
 install(DIRECTORY launch pddl DESTINATION share/${PROJECT_NAME})
 
@@ -41,7 +41,5 @@ if(BUILD_TESTING)
 
   find_package(ament_cmake_gtest REQUIRED)
 endif()
-
-ament_export_dependencies(${dependencies})
 
 ament_package()

--- a/plansys2_simple_example_py/CMakeLists.txt
+++ b/plansys2_simple_example_py/CMakeLists.txt
@@ -11,19 +11,19 @@ find_package(Python3 REQUIRED COMPONENTS Interpreter Development)
 
 ament_python_install_package(${PROJECT_NAME})
 
-set(CMAKE_CXX_STANDARD 17)
+
 
 set(dependencies
-    rclcpp
-    plansys2_msgs
-    plansys2_executor
+    rclcpp::rclcpp
+    plansys2_executor::plansys2_executor
+    ${plansys2_msgs_TARGETS}
 )
 
 add_executable(move_action_node src/move_action_node.cpp)
-ament_target_dependencies(move_action_node ${dependencies})
+target_link_libraries(move_action_node PUBLIC ${dependencies})
 
 add_executable(ask_charge_action_node src/ask_charge_action_node.cpp)
-ament_target_dependencies(ask_charge_action_node ${dependencies})
+target_link_libraries(ask_charge_action_node PUBLIC ${dependencies})
 
 install(DIRECTORY launch pddl DESTINATION share/${PROJECT_NAME})
 
@@ -46,7 +46,5 @@ if(BUILD_TESTING)
 
   find_package(ament_cmake_gtest REQUIRED)
 endif()
-
-ament_export_dependencies(${dependencies})
 
 ament_package()


### PR DESCRIPTION
Hi,

Related to https://github.com/PlanSys2/ros2_planning_system/pull/373. Now, we will use `geometry_msgs::msg::Pose` instead of `geometry_msgs::msg::Pose2D`, which now has moved to `vision_msgs::msg::Pose2D`.

It also includes a commit to remove the deprecated `ament_target_dependencies' .